### PR TITLE
Features/patterns ipaddresses

### DIFF
--- a/config/rules.json.sample
+++ b/config/rules.json.sample
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "types": {
         "security_group": {
             "description": "Check each rule on each security group and on each source",
@@ -24,11 +24,6 @@
                     "description": "Check if ports is a specific port (or range) (like 9000-9001)",
                     "value": "port_range",
                     "variable": "ports"
-                }, {
-                    "type": "is_cidr",
-                    "description": "Check if source is a valid CIDR block",
-                    "value": true,
-                    "variable": "source"
                 },{
                     "type": "is_private_cidr",
                     "description": "Check if source is not a private CIDR block - RFC 1918",
@@ -56,11 +51,6 @@
                     "type": "in",
                     "value": "all",
                     "variable": "ports"
-                },{
-                    "type": "is_cidr",
-                    "description": "Check if source is a valid CIDR block",
-                    "value": true,
-                    "variable": "source"
                 }, {
                     "type": "is_private_cidr",
                     "description": "Check if source is not a private CIDR block - RFC 1918",
@@ -88,11 +78,6 @@
                     "type": "in",
                     "value": "all",
                     "variable": "ports"
-                },{
-                    "type": "is_cidr",
-                    "description": "Check if source is a valid CIDR block",
-                    "value": true,
-                    "variable": "source"
                 }, {
                     "type": "is_private_cidr",
                     "description": "Check if source is a private CIDR block - RFC 1918",
@@ -122,11 +107,6 @@
                     "value": "port_range",
                     "variable": "ports"
                 }, {
-                    "type": "is_cidr",
-                    "description": "Check if source is a valid CIDR block",
-                    "value": true,
-                    "variable": "source"
-                },{
                     "type": "is_private_cidr",
                     "description": "Check if source is a private CIDR block - RFC 1918",
                     "value": true,

--- a/libs/patterns.py
+++ b/libs/patterns.py
@@ -157,6 +157,39 @@ class Patterns:
             return False
         return ip_network.is_private == is_private_cidr
 
+    def _check_rule_is_in_networks(self, source, networks):
+        """Check if source is in one of the networks
+        Check rule "is_in_specific_networks"
+
+        :param source: Value we want to validate as a private CIDR
+        :type source: str
+        :param networks: List of networks we want to check check
+        :type networks: list
+        """
+        self._logger.debug(f'Check rule is_in_networks. Source: {source} | networks: {networks}')
+        if not isinstance(networks, list):
+            self._logger.warnig(f'Bad format for networks. Got {type(networks)} instead of list')
+            return False
+        try:
+            ip_network = ipaddress.ip_network(source)
+        except ValueError:
+            self._logger.warning(f'Unable to create ip_network from {source}: Bad format!')
+            return False
+        except Exception as e:
+            self._logger.warning(f'Error in creating ip_network from {source}: {e}')
+            return False
+        for network_str in networks:
+            try:
+                network = ipaddress.ip_network(network_str)
+            except ValueError:
+                self._logger.warning(f'Unable to create ip_network from {source}: Bad format!')
+                continue
+            except Exception as e:
+                self._logger.warning(f'Error in creating ip_network from {source}: {e}')
+                continue
+            if network.supernet_of(ip_network):
+                return True
+        return False
 
     def _check_rule_type_regex(self, ports, type_regex):
         """Check if ports if valid via regex

--- a/libs/patterns.py
+++ b/libs/patterns.py
@@ -258,12 +258,14 @@ class Patterns:
                     return False
         return report_message
 
-    def _check_findings_by_type(self, findings_type, **kwargs):
+    def _check_findings_by_type(self, findings_type, loop=True, **kwargs):
         """Check every finding rule on kwargs
         Example: Try to check if a source is a valid CIDR and is a private CIDR
 
         :param findings_type: Findings to use like metadata, security_groups, ...
         :type findings_type: str
+        :param loop: If True then we don't stop after the first finding found
+        :type loop: bool, optional
         :return: Report generated from the findings
         :rtype: list
         """
@@ -301,6 +303,8 @@ class Patterns:
                 )
                 if report_message is not False:
                     report.append(report_message)
+                    if loop is False:
+                        break
         return report
 
     def extract_findings_from_security_groups(self, metadata):
@@ -320,6 +324,7 @@ class Patterns:
                     for source in sources:
                         result = self._check_findings_by_type(
                             'security_group',
+                            loop=False,
                             sg_name=sg_name,
                             ports=ports,
                             source=source


### PR DESCRIPTION
Use ipaddress builtin instead of regex to manipulate ip address / network
Add new rule `is_in_networks` to check if a source is a subnet of one of  the networks.

Example of rule:
```json
{
    "message": "Finding to check if our source is a subnet of 192.168.0.0/16",
    "rules": [{
        "type": "type_regex",
        "description": "Check if ports is a specific port (or range) (like 9000-9001)",
        "value": "port_range",
        "variable": "ports"
    }, {
        "type": "is_in_networks",
        "description": "Check if source is in 192.168.0.0/16",
        "value": ["192.168.0.0/16"],
        "variable": "source"
    }],
    "severity": "low"
}
```